### PR TITLE
change karma-requirejs version from ~0.1.0 to ~0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-open": "~0.2.0",
     "karma-ng-scenario": "~0.1.0",
     "grunt-karma": "~0.6.2",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.0",
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-script-launcher": "~0.1.0",


### PR DESCRIPTION
From this error 

'npm ERR! peerinvalid The package karma-requirejs does not satisfy its siblings' peerDependencies requirements!'. 

I have to change karma-requirejs from ~0.1.0 to ~0.2.0 and run npm install again
